### PR TITLE
Add Backup Infrastructure

### DIFF
--- a/ss13-db-backup
+++ b/ss13-db-backup
@@ -2,11 +2,8 @@
 # ss13-db-backup
 # use mysqldump to dump a SQL backup of the starfly13 database container
 
-# ensure the backup directory exists
-mkdir -p /tmp/backup
-
-# dump the database to a compressed SQL file in the backup directory
+# dump the database to a compressed SQL file on standard out
 MYSQL_ROOT_PASSWORD=$(head -1 config/dbconfig.txt | awk -e '{print $3}')
 docker exec --interactive --tty starfly_db \
 	mysqldump --password=${MYSQL_ROOT_PASSWORD} starfly13 \
-	| gzip > /tmp/backup/mariadb.sql.gz
+	| gzip -

--- a/ss13-db-backup
+++ b/ss13-db-backup
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# ss13-db-backup
+# use mysqldump to dump a SQL backup of the starfly13 database container
+
+# ensure the backup directory exists
+mkdir -p /tmp/backup
+
+# dump the database to a compressed SQL file in the backup directory
+MYSQL_ROOT_PASSWORD=$(head -1 config/dbconfig.txt | awk -e '{print $3}')
+docker exec --interactive --tty starfly_db \
+	mysqldump --password=${MYSQL_ROOT_PASSWORD} starfly13 \
+	| gzip > /tmp/backup/mariadb.sql.gz


### PR DESCRIPTION
## About The Pull Request
Adds a `ss13-db-backup` script to create a SQL backup of the database

## Why It's Good For The Game
We can recreate the database if it gets lost and/or damaged beyond repair

## Changelog
:cl:
server: Adds script for backup infrastructure
/:cl:
