### PR TITLE
Fix Infrastructure Scripts

### DIFF
--- a/ss13-db-backup
+++ b/ss13-db-backup
@@ -4,6 +4,6 @@
 
 # dump the database to a compressed SQL file on standard out
 MYSQL_ROOT_PASSWORD=$(head -1 config/dbconfig.txt | awk -e '{print $3}')
-docker exec --interactive --tty starfly_db \
+docker exec starfly_db \
 	mysqldump --password=${MYSQL_ROOT_PASSWORD} starfly13 \
 	| gzip -

--- a/ss13-start
+++ b/ss13-start
@@ -2,8 +2,8 @@
 # ss13-start
 # run the starfly13 service in a container
 
-#	--detach \
 docker run \
+	--detach \
 	--link starfly_db:starfly_db \
 	--name=starfly13 \
 	--publish 1337:1337 \


### PR DESCRIPTION
## About The Pull Request
Fixes minor issues in two infrastructure scripts:
`ss13-start`: Add the `--detach` flag so that the game service container can run in the background
`ss13-db-backup`: Remove the `--interactive` and `--tty` flags; this script is intended for automated, not interactive, use.

## Why It's Good For The Game
Just some quality of life adjustments in the infrastructure scripts

## Changelog
:cl:
server: Fixed some minor issues in the infrastructure scripts
/:cl:
