### PR TITLE
Server Configuration Changes from Baredolf

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -312,12 +312,12 @@ GLOBAL_VAR(restart_counter)
 
 	s += "<b>[station_name()]</b>";
 	s += " ("
-	s += "<a href=\"https://shiptest.net/discord\">" //Change this to wherever you want the hub to link to.
+	s += "<a href=\"[CONFIG_GET(string/discordurl)]\">" //Change this to wherever you want the hub to link to.
 	s += "Discord"  //Replace this with something else. Or ever better, delete it and uncomment the game version.
 	s += "</a>"
 	s += ")"
 	s += " ("
-	s += "<a href=\"https://github.com/shiptest-ss13/Shiptest\">"
+	s += "<a href=\"[CONFIG_GET(string/githuburl)]\">"
 	s += "Github"
 	s += "</a>"
 	s += ")"

--- a/code/modules/language/draconic.dm
+++ b/code/modules/language/draconic.dm
@@ -66,5 +66,3 @@
 	)
 	icon_state = "lizard"
 	default_priority = 90
- 
-

--- a/config/config.txt
+++ b/config/config.txt
@@ -17,10 +17,10 @@ $include atmos_mix.txt
 # There are various options which are hard-locked for security reasons.
 
 ## Server name: This appears at the top of the screen in-game and in the BYOND hub. Uncomment and replace 'Shiptest' with the name of your choice.
-# SERVERNAME Shiptest
+SERVERNAME Starfly13
 
 ## Server SQL name: This is the name used to identify the server to the SQL DB, distinct from SERVERNAME as it must be at most 32 characters.
-# SERVERSQLNAME shiptest
+SERVERSQLNAME starfly13
 
 ## Station name: The name of the station as it is referred to in-game. If commented out, the game will generate a random name instead.
 STATIONNAME Space Station 13
@@ -217,7 +217,7 @@ VOTE_AUTOTRANSFER_INTERVAL 18000
 # DONT_DEL_NEWMOB
 
 ## set a hosted by name for unix platforms
-HOSTEDBY Yournamehere
+HOSTEDBY LectroNyx
 
 ## Set to jobban "Guest-" accounts from Captain, HoS, HoP, CE, RD, CMO, Warden, Security, Detective, and AI positions.
 ## Set to 1 to jobban them from those positions, set to 0 to allow them.
@@ -258,19 +258,19 @@ CHECK_RANDOMIZER
 # SERVER ss13.example.com:2506
 
 ## Lore address
-# LOREURL https://shiptest.net/wiki/Lore_Primer
+LOREURL https://wiki.starfly13.space/index.php/Lore_Primer
 
 ## Wiki address
-# WIKIURL https://shiptest.net/wiki/
+WIKIURL https://wiki.starfly13.space/
 
 ## Rules address
-# RULESURL https://shiptest.net/wiki/Rules
+RULESURL https://wiki.starfly13.space/index.php/Rules
 
 ## Github address
-# GITHUBURL https://github.com/Shiptest-SS13/Shiptest
+GITHUBURL https://github.com/Starfly-13/STARFLY-13
 
 ## Discord address
-# DISCORDURL https://shiptest.net/discord
+DISCORDURL https://discord.gg/ynY7MXHfbh
 
 ## Map viewer address, will have `?=[map_short_name]` appended to it
 # MAPVIEWERURL https://shiptest.net/map
@@ -408,7 +408,7 @@ AUTOCONVERT_NOTES
 ANNOUNCE_ADMIN_LOGOUT
 
 ## Uncomment to have an admin message sent anytime an admin connects to a round in play, you can edit the messages in admin.dm
-#ANNOUNCE_ADMIN_LOGIN
+ANNOUNCE_ADMIN_LOGIN
 
 ## Map rotation
 ## You should edit maps.txt to match your configuration when you enable this.

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -32,8 +32,8 @@ EMOJIS
 ## To speed things up make the number negative, to slow things down, make the number positive.
 
 ## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
-RUN_DELAY 1.5
-WALK_DELAY 3
+RUN_DELAY 2
+WALK_DELAY 3.5
 
 ## The variables below affect the movement of specific mob types. THIS AFFECTS ALL SUBTYPES OF THE TYPE YOU CHOOSE!
 ## Entries completely override all subtypes. Later entries have precedence over earlier entries.
@@ -49,24 +49,24 @@ MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal 1
 
 ## NAMES ###
 ## If uncommented this adds a random surname to a player's name if they only specify one name.
-#HUMANS_NEED_SURNAMES
+HUMANS_NEED_SURNAMES
 
 ## If uncommented, this forces all players to use random names !and appearances!.
 #FORCE_RANDOM_NAMES
 
 ## Unhash this to turn on automatic reopening of a player's job if they suicide at roundstart
-#REOPEN_ROUNDSTART_SUICIDE_ROLES
+REOPEN_ROUNDSTART_SUICIDE_ROLES
 
 ## Unhash to enable reopening of command level positions
-#REOPEN_ROUNDSTART_SUICIDE_ROLES_COMMAND_POSITIONS
+REOPEN_ROUNDSTART_SUICIDE_ROLES_COMMAND_POSITIONS
 
 ## Define the delay for roles to be reopened after the round starts in seconds.
 ## Has a minimum delay of 30 seconds, though it's suggested to keep over 1 min
 ## If undefined, the delay defaults to 4 minutes.
-#REOPEN_ROUNDSTART_SUICIDE_ROLES_DELAY 240
+REOPEN_ROUNDSTART_SUICIDE_ROLES_DELAY 240
 
 ## Unhash to enable a printed command report for reopened roles listing what roles were reopened.
-#REOPEN_ROUNDSTART_SUICIDE_ROLES_COMMAND_REPORT
+REOPEN_ROUNDSTART_SUICIDE_ROLES_COMMAND_REPORT
 
 
 ## ALERT LEVELS ###
@@ -302,7 +302,7 @@ MINIMAL_ACCESS_THRESHOLD 20
 #ASSISTANTS_HAVE_MAINT_ACCESS
 
 ## Uncoment to give security maint access. Note that if you dectivate JOBS_HAVE_MINIMAL_ACCESS security already gets maint from that.
-#SECURITY_HAS_MAINT_ACCESS
+SECURITY_HAS_MAINT_ACCESS
 
 ## Uncomment to give everyone maint access.
 #EVERYONE_HAS_MAINT_ACCESS
@@ -353,9 +353,9 @@ RANDOM_LAWS corporate
 
 ## Quirky laws. Shouldn't cause too much harm
 #RANDOM_LAWS hippocratic
-#RANDOM_LAWS maintain
+RANDOM_LAWS maintain
 #RANDOM_LAWS drone
-#RANDOM_LAWS liveandletlive
+RANDOM_LAWS liveandletlive
 #RANDOM_LAWS peacekeeper
 #RANDOM_LAWS reporter
 #RANDOM_LAWS hulkamania
@@ -473,7 +473,7 @@ OVERFLOW_CAP -1
 
 ## Starlight for exterior walls and breaches. Uncomment for starlight!
 ## This is disabled by default to make testing quicker, should be enabled on production servers or testing servers messing with lighting
-#STARLIGHT
+STARLIGHT
 
 ## Uncomment to bring back old grey suit assistants instead of the now default rainbow colored assistants.
 #GREY_ASSISTANTS
@@ -533,7 +533,7 @@ SMUGGLER_SATCHELS 3
 #EMERGENCY_SHUTTLE_AUTOCALL_THRESHOLD 0.2
 
 ## Determines if players are allowed to print integrated circuits, uncomment to allow.
-#IC_PRINTING
+IC_PRINTING
 
 ## Uncomment to allow roundstart quirk selection in the character setup menu.
 ## This used to be named traits, hence the config name, but it handles quirks, not the other kind of trait!
@@ -549,7 +549,7 @@ ROUNDSTART_TRAITS
 #RANDOMIZE_SHIFT_TIME
 
 ## Sets shift time to server time at roundstart. Overridden by RANDOMIZE_SHIFT_TIME ##
-#SHIFT_TIME_REALTIME
+SHIFT_TIME_REALTIME
 
 ## A cap on how many monkeys may be created via monkey cubes
 MONKEYCAP 64
@@ -575,7 +575,7 @@ MAX_OVERMAP_EVENTS 50
 MAX_OVERMAP_DYNAMIC_EVENTS 10
 
 ## Size of the overmap squared
-OVERMAP_SIZE 12
+OVERMAP_SIZE 15
 
 ## Which overmap generator to use
 ## Valid values are: "random", "solar_system"


### PR DESCRIPTION
## Editor's Note
These changes were originally provided by Baredolf.
I have opened this PR on behalf of Baredolf, as we wait for GitHub support to detach the Starfly-13 fork.
I have made some minor changes, awaiting Baredolf's review/approval.

## About The Pull Request
* Changes configs to setup basic functions
* Enabled lighting environment
* Setup verbs to link correctly
* Increased overmap size
* Give humans Surnames
* Reopen role on roundstart suicide
* Security has maints access
* Enabled two borg lawsets
* Enabled Integrated circuit printing
* Set shift time to reflect on server uptime
* Named the server in the SQL database
* Enabled announcement on admin login

## Why It's Good For The Game
Qol improvements!

## Changelog
:cl:
tweak: tweaked walk speed to be more like shiptest
fix: fixed discord/wiki/rules verbs
code: setup hub hyperlinks if the server is ever put on hub
config: changed a lot config settings
/:cl:
