### PR TITLE
Add CI workflow for building to CR

### DIFF
--- a/.github/workflows/cr_publish.yml
+++ b/.github/workflows/cr_publish.yml
@@ -1,0 +1,46 @@
+name: Publish to Vultr
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker:
+    # skip this workflow if the commit message contains [ci skip]
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    runs-on: ubuntu-latest
+    steps:
+      # generate the images and tags we'll publish to the registry
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            sjc.vultrcr.com/starfly13/starfly13
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value={{date 'YYYYMMDDHHmmss'}}
+            type=sha
+
+      # set up the build
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # log in to the registry
+      - name: Login to Vultr Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: sjc.vultrcr.com
+          username: ${{ secrets.VULTR_USERNAME }}
+          password: ${{ secrets.VULTR_APIKEY }}
+
+      # build and push to the registry
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/cr_publish.yml
+++ b/.github/workflows/cr_publish.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   docker:

--- a/.github/workflows/cr_publish.yml
+++ b/.github/workflows/cr_publish.yml
@@ -27,6 +27,10 @@ jobs:
             type=raw,value={{date 'YYYYMMDDHHmmss'}}
             type=sha
 
+      # check out the code from the repository
+      - name: Checkout Project
+        uses: actions/checkout@v4
+
       # set up the build
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## About The Pull Request
Adds a GitHub workflow to publish docker images to the container registry

## Why It's Good For The Game
We want the build process to be automated and decoupled from the server.

## Changelog
:cl:
server: Support for Container Registry based infrastructure
/:cl:
