### PR TITLE
Fix up a few bugs with Admin Freeze

### DIFF
--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -50,7 +50,7 @@
 	name = "adminoverlay"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "admin"
-	layer = 4.1
+	layer = ABOVE_ALL_MOB_LAYER
 
 /obj/effect/overlay/vis
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT

--- a/code/modules/admin/verbs/freeze.dm
+++ b/code/modules/admin/verbs/freeze.dm
@@ -19,7 +19,7 @@ GLOBAL_LIST_EMPTY(frozen_atom_list) // A list of admin-frozen atoms.
 
 /// Created here as a base proc. Override as needed for any type of object or mob you want able to be frozen.
 /atom/movable/proc/admin_Freeze(client/admin)
-	to_chat(admin, "<span class='warning'>Freeze is not able to be called on this type of object.</span")
+	to_chat(admin, "<span class='warning'>Freeze is not able to be called on this type of object.</span>")
 	return
 
 ///mob freeze procs
@@ -31,7 +31,7 @@ GLOBAL_LIST_EMPTY(frozen_atom_list) // A list of admin-frozen atoms.
 		GLOB.frozen_atom_list += src
 
 		var/obj/effect/overlay/adminoverlay/AO = new
-		if(skip_overlays)
+		if(!skip_overlays)
 			overlays += AO
 
 		anchored = TRUE
@@ -42,7 +42,7 @@ GLOBAL_LIST_EMPTY(frozen_atom_list) // A list of admin-frozen atoms.
 	else
 		GLOB.frozen_atom_list -= src
 
-		if(skip_overlays)
+		if(!skip_overlays)
 			overlays -= frozen
 
 		anchored = FALSE


### PR DESCRIPTION
## About The Pull Request
This fixes up a few issues with the [Admin] Freeze verb:
* Overlay effect is now added to and removed from frozen mobs
* Fixed a typo in a closing </span> tag that wasn't quite all the way closed
* Changed the hardcoded layer value `4.1` to a defined layer constant `ABOVE_ALL_MOB_LAYER`

Fixes #28 

## Why It's Good For The Game
Other players can see admins are intervening with a particular player, and stay away.

## Changelog
:cl:
fix: Fixed a span tag missing a closing bracket
fix: Fixed admin freeze overlay not appearing on frozen mobs
refactor: Changed hardcoded layer value to defined layer constant
admin: Freeze or burn? Freezerburn!
/:cl:
