### PR TITLE
Makes CRYOSLEEP_SYMPTOMS a configurable flag

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -431,3 +431,5 @@
 	max_val = 255
 	config_entry_value = 127
 	min_val = 127
+
+/datum/config_entry/flag/cryosleep_symptoms

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -166,11 +166,15 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod/retro, 17)
 	var/open_sound = 'sound/machines/podopen.ogg'
 	var/close_sound = 'sound/machines/podclose.ogg'
 
+	/// if symptoms of cryosleep will be applied to players upon waking
+	var/apply_cryosleep_symptoms = TRUE
+
 /obj/machinery/cryopod/Initialize()
 	..()
 	if(!preserve_items_typecache)
 		preserve_items_typecache = typecacheof(preserve_items)
 	icon_state = open_state
+	apply_cryosleep_symptoms = CONFIG_GET(flag/cryosleep_symptoms)
 	return INITIALIZE_HINT_LATELOAD //Gotta populate the cryopod computer GLOB first
 
 /obj/machinery/cryopod/Destroy()
@@ -430,6 +434,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod/retro, 17)
 	linked_ship.spawn_points += src
 
 /obj/machinery/cryopod/apply_effects_to_mob(mob/living/carbon/sleepyhead)
+	if(!apply_cryosleep_symptoms)
+		return
 	//it always sucks a little to get up
 	sleepyhead.set_nutrition(200)
 	sleepyhead.SetSleeping(60) //if you read this comment and feel like shitting together something to adjust elzu and IPC charge on wakeup, be my guest.
@@ -448,7 +454,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod/retro, 17)
 	//maybe you should've bought high passage.
 	if(prob(30))
 		sleepyhead.apply_damage_type(15, BURN)
-	to_chat(sleepyhead, "<span class='userdanger'>The symptoms of cryosleep set in as you awaken...")
+	to_chat(sleepyhead, "<span class='userdanger'>The symptoms of cryosleep set in as you awaken...</span>")
 
 
 
@@ -457,6 +463,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod/retro, 17)
 	desc = "Keeps crew frozen in cryostasis until they are needed in order to cut down on supply usage. This one seems cheaply made."
 
 /obj/machinery/cryopod/poor/apply_effects_to_mob(mob/living/carbon/sleepyhead)
+	if(!apply_cryosleep_symptoms)
+		return
 	sleepyhead.set_nutrition(200)
 	sleepyhead.SetSleeping(80)
 	if(prob(90))
@@ -471,4 +479,4 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod/retro, 17)
 		sleepyhead.adjust_disgust(rand(5,15))
 	if(prob(30))
 		sleepyhead.apply_damage_type(30, BURN)
-	to_chat(sleepyhead, "<span class='userdanger'>The symptoms of a horrid cryosleep set in as you awaken...")
+	to_chat(sleepyhead, "<span class='userdanger'>The symptoms of a horrid cryosleep set in as you awaken...</span>")

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -593,3 +593,7 @@ BLUESPACE_JUMP_WAIT 12000
 
 ## If admins are allowed to use the authentication server as a regular server for testing
 AUTH_ADMIN_TESTING
+
+## Apply symptoms of cryosleep to characters when first spawning on a ship
+## Comment this out if you want characters to skip the cryo sickness stuff and jump straight to it
+CRYOSLEEP_SYMPTOMS


### PR DESCRIPTION
## About The Pull Request
When starting the game, characters emerge from a cryopod and experience a random degree of cryosleep symptoms.

This PR adds a configurable flag `CRYOSLEEP_SYMPTOMS` that controls if these effects are applied or not.
When commented out, no cryosleep symptoms will be applied to characters, who can jump straight into it.

## Why It's Good For The Game
I'm not sure that it is? Cyrosleep symptoms are very thematic, but they can also be annoying.
That's why this PR introduces a configurable flag; maybe we want to turn them off, or maybe we don't.

## Changelog
:cl:
fix: Added missing closing span tags
config: Added a new config setting; CRYOSLEEP_SYMPTOMS
/:cl:
