### PR TITLE
Enable FULL_INIT

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,6 +1,6 @@
 /// VERY IMPORTANT FOR RUNNING FAST IN PRODUCTION!
 /// If you define this flag, centcom will load. It's also supposed to preload planetoids, but that is disabled.
-//#define FULL_INIT
+#define FULL_INIT
 
 #ifdef FULL_INIT
 	#include "map_files\generic\CentCom.dmm"


### PR DESCRIPTION
## About The Pull Request
Enables the flag `FULL_INIT` because it will load CentCom ~~and is very important for running fast in production~~.

## Why It's Good For The Game
Load ~~all the~~ the CentCom thing~~s and run fast in production~~.

## Changelog
:cl:
tweak: Enabled FULL_INIT flag
/:cl:
