### PR TITLE
Ship spawn adjustments

### DIFF
--- a/_maps/configs/pgf_crying_sun.json
+++ b/_maps/configs/pgf_crying_sun.json
@@ -46,5 +46,5 @@
 			"slots": 3
 		}
 	},
-	"enabled":true
+	"enabled":false
 }

--- a/_maps/configs/srm_elder.json
+++ b/_maps/configs/srm_elder.json
@@ -8,7 +8,7 @@
 	],
 	"map_short_name": "Elder-class",
 	"map_path": "_maps/shuttles/roumain/srm_elder.dmm",
-	"description": "A standard issue vessel to the highest ranks of the Saint-Roumain Militia. While “standard”, this class of vessel is unique to the Montagne that owns it. Each ship is designed around a central garden consisting of plants, soil, and a tree from the owning Montagnes’ home planet. As a highly religious ascetic order, the SRM supplies each Elder with supplies to farm, raise animals, and perform medicine in more “natural” ways, using herbs and plants grown in house. The ship is captained by a Montagne, who oversees a team of Hunters, and Shadows apprenticing them.",
+	"description": "A standard issue vessel to the highest ranks of the Moffic Church. While “standard”, this class of vessel is unique to the Montagne that owns it. Each ship is designed around a central garden consisting of plants, soil, and a tree from the owning Montagnes’ home planet. As a highly religious ascetic order, the SRM supplies each Elder with supplies to farm, raise animals, and perform medicine in more “natural” ways, using herbs and plants grown in house. The ship is captained by a Montagne, who oversees a team of Hunters, and Shadows apprenticing them.",
 	"tags": [
 		"Botany",
 		"Combat",
@@ -35,5 +35,5 @@
 			"slots": 3
 		}
 	},
-	"enabled": true
+	"enabled": false
 }

--- a/_maps/configs/syndicate_aegis.json
+++ b/_maps/configs/syndicate_aegis.json
@@ -1,5 +1,5 @@
 {
-	"prefix": "SUNS",
+	"prefix": "CSSV",
 	"map_name": "Aegis-class Long Term Care Ship",
 	"map_short_name": "Aegis-class",
 	"map_path": "_maps/shuttles/syndicate/syndicate_aegis.dmm",
@@ -12,29 +12,29 @@
 	"map_id": "syndicate_aegis",
 	"limit": 1,
 	"namelists": [
-		"SUNS",
+		"CYBERSUN",
 		"SPACE",
 		"GENERAL"
 	],
 	"job_slots": {
 		"Captain": {
-			"outfit": "/datum/outfit/job/syndicate/captain/suns",
+			"outfit": "/datum/outfit/job/syndicate/captain/cybersun",
 			"officer": true,
 			"slots": 1
 		},
 
 		"Lead Doctor": {
-			"outfit": "/datum/outfit/job/syndicate/cmo/suns",
+			"outfit": "/datum/outfit/job/syndicate/cmo",
 			"slots": 1
 		},
 
 		"Ship Doctor":{
-			"outfit": "/datum/outfit/job/syndicate/doctor/suns",
+			"outfit": "/datum/outfit/job/syndicate/doctor/cybersun",
 			"slots": 2
 		},
 
 		"Mechanic": {
-			"outfit": "/datum/outfit/job/syndicate/engineer/suns",
+			"outfit": "/datum/outfit/job/syndicate/engineer/cybersun",
 			"slots": 1
 		},
 

--- a/_maps/configs/syndicate_aegis.json
+++ b/_maps/configs/syndicate_aegis.json
@@ -1,9 +1,9 @@
 {
 	"prefix": "CSSV",
-	"map_name": "Aegis-class Long Term Care Ship",
-	"map_short_name": "Aegis-class",
+	"map_name": "Seiiki-class Long Term Care Ship",
+	"map_short_name": "Seiiki-class",
 	"map_path": "_maps/shuttles/syndicate/syndicate_aegis.dmm",
-	"description": "Approximately a third of the way through the ICW, it became apparent that the Syndicate could not muster the sheer throwaway manpower that Nanotrasen could with its swaths of mercenaries and disposable personnel. Instead, the Syndicate began to adopt a much more conservative approach to maintaining personnel, by establishing an initiative to create a host of medical vessels designed to rescue and rehabilitate the fallen. While the Li Tieguai filled the rescue role, the Aegis-Class was to fill the rehabilitation role. Featuring a host of ‘quality of life’ features for long-term patients (a full bar, a hydroponics setup, and so on), an expansive medical bay and an array of comfort fixtures like couches and gardens, the Aegis is perfect for aspiring doctors or wounded patients.",
+	"description": "Approximately a third of the way through the ICW, it became apparent that the Syndicate could not muster the sheer throwaway manpower that Nanotrasen could with its swaths of mercenaries and disposable personnel. Instead, the Syndicate began to adopt a much more conservative approach to maintaining personnel, by establishing an initiative to create a host of medical vessels designed to rescue and rehabilitate the fallen. While the Li Tieguai filled the rescue role, the Seiiki-Class was to fill the rehabilitation role. Featuring a host of ‘quality of life’ features for long-term patients (a full bar, a hydroponics setup, and so on), an expansive medical bay and an array of comfort fixtures like couches and gardens, the Aegis is perfect for aspiring doctors or wounded patients.",
 	"tags": [
 		"Botany",
 		"Medical",

--- a/_maps/configs/syndicate_cybersun_kansatsu.json
+++ b/_maps/configs/syndicate_cybersun_kansatsu.json
@@ -1,13 +1,13 @@
 {
 	"$schema": "https://raw.githubusercontent.com/shiptest-ss13/Shiptest/master/_maps/ship_config_schema.json",
-	"prefix": "CSSV",
+	"prefix": "RGSV",
 	"namelists": [
 		"CYBERSUN",
 		"SPACE",
 		"NATURAL_AGGRESSIVE"
 	],
 	"map_name": "Kansatsu-class Scout Courier",
-	"description": "The Kansatsu-class is a Cybersun remodel of the old Type-S SolGov Courier, rebuilt for rapid package ferrying and light surveillance operations in the Frontier. While fairly cramped, it excels at its design goals, with rapid surveys, scouting, and espionage flowing from its presence. Syndicate deployments typically include a deployment of 5, with a recommended max of 7. This is broken down into 1 captain, an intelligence officer for coordinating the field agents, an engineer, and 2 field agents. The simplicity of the hull has led to the ship becoming a widespread indicator of Syndicate interest in locations, and some models have found their way into private purchasers' hands.",
+	"description": "The Kansatsu-class is a Roseus Galactic remodel of the old Type-S SolGov Courier, rebuilt for rapid package ferrying and light surveillance operations in the Frontier. While fairly cramped, it excels at its design goals, with rapid surveys, scouting, and espionage flowing from its presence. Syndicate deployments typically include a deployment of 5, with a recommended max of 7. This is broken down into 1 captain, an intelligence officer for coordinating the field agents, an engineer, and 2 field agents. The simplicity of the hull has led to the ship becoming a widespread indicator of Syndicate interest in locations, and some models have found their way into private purchasers' hands.",
 	"tags": [
 		"Specialist"
 	],

--- a/_maps/configs/syndicate_cybersun_kansatsu.json
+++ b/_maps/configs/syndicate_cybersun_kansatsu.json
@@ -6,12 +6,12 @@
 		"SPACE",
 		"NATURAL_AGGRESSIVE"
 	],
-	"map_name": "Kansatsu-class Scout Courier",
-	"description": "The Kansatsu-class is a Roseus Galactic remodel of the old Type-S SolGov Courier, rebuilt for rapid package ferrying and light surveillance operations in the Frontier. While fairly cramped, it excels at its design goals, with rapid surveys, scouting, and espionage flowing from its presence. Syndicate deployments typically include a deployment of 5, with a recommended max of 7. This is broken down into 1 captain, an intelligence officer for coordinating the field agents, an engineer, and 2 field agents. The simplicity of the hull has led to the ship becoming a widespread indicator of Syndicate interest in locations, and some models have found their way into private purchasers' hands.",
+	"map_name": "Soundcheck-class Scout Courier",
+	"description": "The Soundcheck-class is a Roseus Galactic remodel of the old Type-S SolGov Courier, rebuilt for rapid package ferrying and light surveillance operations in the Frontier. While fairly cramped, it excels at its design goals, with rapid surveys, scouting, and espionage flowing from its presence. Syndicate deployments typically include a deployment of 5, with a recommended max of 7. This is broken down into 1 captain, an intelligence officer for coordinating the field agents, an engineer, and 2 field agents. The simplicity of the hull has led to the ship becoming a widespread indicator of Syndicate interest in locations, and some models have found their way into private purchasers' hands.",
 	"tags": [
 		"Specialist"
 	],
-	"map_short_name": "Kansatsu-class",
+	"map_short_name": "Soundcheck-class",
 	"map_path": "_maps/shuttles/syndicate/syndicate_cybersun_kansatsu.dmm",
 	"map_id": "cybersun_kansatsu",
 	"job_slots": {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Couple things are done here. One, PGF is disabled, as is SRM for the time being. Two, I've started some adjustments on the Aegis, which will ultimately become a Cybersun ship. Another ship, of course, is being made Roseus.

## Why It's Good For The Game

We're taking out these 3 factions - PGF, SRM, and SUNS - due to not fitting with the lore. That said, the SRM ship's been adjusted so that some of the text better fits the Moffic Church that Ovilum's working on. I'm hesitant to do much there, since I want him to have more input on his faction's ship. It will become playable again once the church is better established, though I'm leaving the ball largely in his court.

Our shift away from the Sarathi leaves the PGF in a weird spot, and I don't really want to keep them around in my lore. They're Space America, and frankly, that's what SolFed's usually for. Since we want to be more approachable for people used to regular SS13 lore, giving SolFed's gimmick away to someone else feels like change for the sake of being different and not better - that's not what we're after at all. Maybe this ship will eventually be given a SolFed coat of paint once that whole mess gets sorted out, but for now it's being made non-playable in order to help avoid accidental lore violations.

SUNS is being removed, with Cybersun being the medical faction. SUNS, here, has a really weird position it's stuck in because it treads on the aesthetic we want for Roseus Galactic while sharing functionality with Cybersun. While one could try to argue Roseus Galactic is in the same situation, this is ultimately false - while Cybersun has one ship that touches on Roseus' role, they don't have any emphasis on it at all. Cybersun is otherwise, overwhelmingly, a medical faction - their other ship is medical, all of their ads are medical, they fit this slot very well. Roseus Galactic was already credited for the Infiltrator Suit in /TG/code (via the description in the uplink), which carried over to Shiptest due to people not paying much attention to the contents of their code. In our lore, Roseus Galactic is the intelligence and espionage faction - saboteurs and basic agents at their loudest. These are spies and celebrities, both actors in their own rights, as well as the staff that takes care of them. Makeup artists, security, etc. With that in mind, it only makes sense that the ship focused on infiltration and deception be given to the faction focused on intelligence gathering and acting. SUNS aesthetic is being given to Roseus Galactic because they are the least redundant of the two factions. If we ever need an additional medical faction, we'll most likely bring over Interdyne Pharmaceuticals - however, for now, what we have is enough. SUNS is only taking one faction's aesthetic while competing with another faction over the same job and not enough to really set them apart in any interesting way.

TL;DR: Lorebreaking ship is aspawn only, Moffic Church ship aspawn only until the faction gets more writing, SUNS is being disbanded with its Aegis being given to Cybersun, Roseus Galactic is gaining a little more presence by acquiring a Cybersun ship that doesn't fit the faction.

## Changelog

:cl:
del: PGF ship made aspawn. BYEBYE. BYEBYE.
del: SRM ship made aspawn until further notice.
tweak: Aegis made Cybersun
tweak: Kansatsu made Roseus
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
