### PR TITLE
removed suns poster from twinkleshine

### DIFF
--- a/_maps/shuttles/syndicate/syndicate_twinkleshine.dmm
+++ b/_maps/shuttles/syndicate/syndicate_twinkleshine.dmm
@@ -8924,9 +8924,6 @@
 /obj/effect/turf_decal/industrial/warning{
 	dir = 6
 	},
-/obj/structure/sign/poster/solgov/suns{
-	pixel_x = 32
-	},
 /obj/structure/crate_shelf,
 /turf/open/floor/pod/dark,
 /area/ship/cargo)


### PR DESCRIPTION
## About The Pull Request

NT disabled the Syndicate's ultimate battlecruiser using this one simple piece of paper!

so we burned that shit lol

## Why It's Good For The Game

this poster no longer exists in our code, so its mention on this map rendered the entire ship unplayable!

## Changelog

:cl:
del: Removed SUNS poster from Twinkleshine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
