### PR TITLE
Add new QA check for FILE_DIR to CI

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,4 +1,4 @@
-name: Build Linux
+name: QA
 on:
   push:
     branches:
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install BYOND
         run: tools/starfly/ci/install_byond_linux.sh

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -1,4 +1,4 @@
-name: Build Windows
+name: QA
 on:
   push:
     branches:
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build Project
         run: pwsh tools/starfly/ci/build.ps1

--- a/.github/workflows/check_file_dir.yml
+++ b/.github/workflows/check_file_dir.yml
@@ -1,0 +1,30 @@
+name: QA
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  merge_group:
+    branches:
+      - master
+
+jobs:
+  check_file_dir:
+    if: ${{ !contains(github.event.head_commit.message, '[ci skip]') }}
+    name: "Check (FILE_DIR)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v4
+
+      - name: Check FILE_DIR
+        run: |
+          count=$(grep -o 'FILE_DIR' shiptest.dme | wc -l)
+          if [[ "$count" -ne 3 ]]; then
+              echo "Error: shiptest.dme contains $count instances of FILE_DIR, expected exactly 3."
+              echo "See: https://tgstation13.org/phpBB/viewtopic.php?f=5&t=321"
+              exit 1
+          fi
+          echo "Success: shiptest.dme contains exactly 3 instances of FILE_DIR."


### PR DESCRIPTION
## About The Pull Request
This PR adds a new check to Continuous Integration (CI) for `FILE_DIR` in `shiptest.dme`.

The reason we don't want this showing up in our .dme file (and how to fix it!) is given here:
https://tgstation13.org/phpBB/viewtopic.php?f=5&t=321

## Why It's Good For The Game
It makes sure the quality of the code stays high.
