### PR TITLE
Calendar adjustment

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -21,7 +21,7 @@
 /proc/sector_datestamp(realtime = world.realtime, shortened = FALSE)
 	//International Fixed Calendar format (https://en.wikipedia.org/wiki/International_Fixed_Calendar)
 	var/days_since = round(realtime / (24 HOURS))
-	var/year = round(days_since / 365) + 481
+	var/year = round(days_since / 365) + 2540
 	var/day_of_year = days_since % 365
 	var/month = round(day_of_year / 28)
 	var/day_of_month = day_of_year % 28 + 1
@@ -58,9 +58,9 @@
 		if(12)
 			monthname = "December"
 		if(13)
-			return "Year Day, [year] FSC"
+			return "Year Day, [year] CE"
 
-	return "[monthname] [day_of_month], [year] FSC"
+	return "[monthname] [day_of_month], [year]"
 
 //returns timestamp in a sql and a not-quite-compliant ISO 8601 friendly format
 /proc/SQLtime(timevar)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the calendar fit our lore - 505 was centuries ago, and FSC doesn't exist. The year is 2564, as of writing this... 2540 years into the future!

## Why It's Good For The Game

LORE NEEDS TO BE PRESENT AND REPRESENTED INGAME TO MATTER

## Changelog

:cl:
code: Changed the year and calendar system label to fit the STARFLY-13 lore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
